### PR TITLE
Clean up ast

### DIFF
--- a/src/main/scala/net/common/Error.scala
+++ b/src/main/scala/net/common/Error.scala
@@ -7,14 +7,15 @@ object Error {
 	sealed trait LispError
 	case class ParseError(ex: Throwable) extends LispError
 	
-	sealed trait InterpretterError extends LispError
-	case object BadIfError         extends InterpretterError
-	case object BadDefineError     extends InterpretterError
-	case object EmptyExpression	   extends InterpretterError
-	case object ProcError		   extends InterpretterError
-	case object NoVarExists		   extends InterpretterError
-	case object SetError		   extends InterpretterError
-	case object LambdaNotAllowed   extends InterpretterError
+	sealed trait InterpretterError      extends LispError
+	case class BadIfResultError(x: Any) extends InterpretterError
+	case object BadDefineError          extends InterpretterError
+	case object EmptyExpression	   	    extends InterpretterError
+	case class ProcError(f: String)     extends InterpretterError
+	case class NoVarExists(v: String)   extends InterpretterError
+	case object SetError		   	    extends InterpretterError
+	case object LambdaNotAllowed        extends InterpretterError
+	case object NoBoolInIfCondition     extends InterpretterError
 	
 	sealed trait InvalidLambda     									 extends InterpretterError
 	case class WrongNumArgs(fields: List[String], values: List[Any]) extends InvalidLambda

--- a/src/main/scala/net/parser/AST.scala
+++ b/src/main/scala/net/parser/AST.scala
@@ -31,16 +31,9 @@ object AST {
 	sealed trait MValue
 	sealed trait SingleValue extends MValue
 	case class Val(x: Any) extends SingleValue
-	case class Fn(f: Function2[List[Any], M, EvalResult]) extends MValue
+	case class Fn(f: Function2[List[Any], M, Either[(LispError, M), (MValue, M)]]) extends MValue
 
 	type M = Map[String, MValue]
-
-	sealed trait EvalResult
-	case class Complete(res: Either[(LispError, M), (SingleValue, M)]) extends EvalResult
-	case class Partial(f: Function2[List[Any], M, EvalResult]) extends EvalResult
-
-	implicit def eitherResultToComplete(x: Either[(LispError, M), (SingleValue, M)]): EvalResult = 
-		Complete(x)
 
 	sealed trait MapUpdateOp 
 	case class SetOp(v: String, value: Any) extends MapUpdateOp

--- a/src/main/scala/net/repl/LispRepl.scala
+++ b/src/main/scala/net/repl/LispRepl.scala
@@ -11,25 +11,25 @@ import scalaz.effect.IO._
 
 object LispRepl {
 
-	// def runForever(map: M): IO[Unit] = for {
-	// 	input  <- readLn
-	// 	_      <- putStrLn(s">$input")
-	// 	result <- IO(runSingle(input, map))
-	// 	_ 	   <- putStrLn(result.toString)
-	// 	_ 	   <- runForever(getMap(result, map))
-	// } yield ()
+	def runForever(map: M): IO[Unit] = for {
+		input  <- readLn
+		_      <- putStrLn(s">$input")
+		result <- IO(runSingle(input, map))
+		_ 	   <- putStrLn(result.toString)
+		_ 	   <- runForever(getMap(result, map))
+	} yield ()
 
-	// def runSingle(input: String, map: M): EvalResult = 
-	// 	parse(input) match {
-	// 		case Success(e)  => interpret(e, map)
-	// 		case Failure(ex) => Left((ParseError(ex), map))
-	// 	}
+	def runSingle(input: String, map: M): Either[(LispError, M), (MValue, M)] = 
+		parse(input) match {
+			case Success(e)  => interpret(e, map)
+			case Failure(ex) => Left((ParseError(ex), map))
+		}
 
-	// def interpret(s: SExpr, map: M): EvalResult = 
-	// 	LispInterpretter.evaluate(s)(map)
+	def interpret(s: SExpr, map: M): Either[(LispError, M), (MValue, M)] = 
+		LispInterpretter.evaluate(s)(map)
 
-	// def parse(x: String): Try[SExpr] = 
-	// 	new LispParser(x).SExprComplete.run() 
+	def parse(x: String): Try[SExpr] = 
+		new LispParser(x).SExprComplete.run() 
 	
 	def getMap(res: Either[(LispError, M), (MValue, M)], previousMap: M): M = res match {
 		case Right((_, m)) => m

--- a/src/main/scala/net/repl/LispRepl.scala
+++ b/src/main/scala/net/repl/LispRepl.scala
@@ -11,33 +11,28 @@ import scalaz.effect.IO._
 
 object LispRepl {
 
-	def runForever(map: M): IO[Unit] = for {
-		input  <- readLn
-		_      <- putStrLn(s">$input")
-		result <- IO(runSingle(input, map))
-		_ 	   <- putStrLn(result.toString)
-		_ 	   <- runForever(getMap(result, map))
-	} yield ()
+	// def runForever(map: M): IO[Unit] = for {
+	// 	input  <- readLn
+	// 	_      <- putStrLn(s">$input")
+	// 	result <- IO(runSingle(input, map))
+	// 	_ 	   <- putStrLn(result.toString)
+	// 	_ 	   <- runForever(getMap(result, map))
+	// } yield ()
 
-	def runSingle(input: String, map: M): EvalResult = 
-		parse(input) match {
-			case Success(e)  => interpret(e, map)
-			case Failure(ex) => Left((ParseError(ex), map))
-		}
+	// def runSingle(input: String, map: M): EvalResult = 
+	// 	parse(input) match {
+	// 		case Success(e)  => interpret(e, map)
+	// 		case Failure(ex) => Left((ParseError(ex), map))
+	// 	}
 
-	def interpret(s: SExpr, map: M): EvalResult = 
-		LispInterpretter.evaluate(s)(map)
+	// def interpret(s: SExpr, map: M): EvalResult = 
+	// 	LispInterpretter.evaluate(s)(map)
 
-	def parse(x: String): Try[SExpr] = 
-		new LispParser(x).SExprComplete.run() 
+	// def parse(x: String): Try[SExpr] = 
+	// 	new LispParser(x).SExprComplete.run() 
 	
-	def getMap(res: EvalResult, previousMap: M): M = res match {
-		case Complete(xs) => getM(xs)
-		case Partial(_)   => previousMap
-	}
-
-	private def getM[A, B](res: Either[(A, M), (B, M)]): M = res match {
-		case Right(x) => x._2
-		case Left(x) => x._2
+	def getMap(res: Either[(LispError, M), (MValue, M)], previousMap: M): M = res match {
+		case Right((_, m)) => m
+		case Left(_)       => previousMap
 	}
 }

--- a/src/test/scala/net/interpretter/LispInterpretterTest.scala
+++ b/src/test/scala/net/interpretter/LispInterpretterTest.scala
@@ -12,137 +12,136 @@ class LispInterpretterTest extends FlatSpec {
 	
 	val empty: M = Map()
 
+	// helper function to avoid copy-ing `Val(...)` throughout all tests
 	implicit def anyToSingleValue(x: Any): SingleValue = Val(x)
 
 	"The Lisp Interpretter" should "return the number itself for a Number" in {
 		val parsed = new LispParser("5").SExprComplete.run()
-		testSuccessfulEval(parsed, Complete(Right((5, empty))), empty)
+		testSuccessfulEval(parsed, Right((5, empty)), empty)
 	}
 
 	"The Lisp Interpretter" should "return the string literal itself for an Ident" in {
 		val parsed = new LispParser("\"foo3\"").SExprComplete.run()
-		testSuccessfulEval(parsed, Complete(Right(("\"foo3\"", empty))), empty)
+		testSuccessfulEval(parsed, Right(("\"foo3\"", empty)), empty)
 	}	
 
 	"The Lisp Interpretter" should "return the variable's value for an existing variable" in {
 		val parsed = new LispParser("x").SExprComplete.run()
 		val map = Map("x" -> Val(456))
-		testSuccessfulEval(parsed, Complete(Right(((Val(456), map)))), map)
+		testSuccessfulEval(parsed, Right(((Val(456), map))), map)
 	}	
 
 	"The Lisp Interpretter" should "fail for a non-existing variable" in {
 		val parsed = new LispParser("x").SExprComplete.run()
-		testSuccessfulEval(parsed, Complete(Left((NoVarExists, Map()))), empty)
+		testSuccessfulEval(parsed, Left((NoVarExists("x"), Map())), empty)
 	}		
 
 	"The Lisp Interpretter" should "return true for a '>' test" in {
 		val parsed = new LispParser("(> 1000 1)").SExprComplete.run()
-		testSuccessfulEval(parsed, Complete(Right(((true, Map())))), empty)
+		testSuccessfulEval(parsed, Right(((true, Map()))), empty)
 	}		
 
 	"The Lisp Interpretter" should "return false for a '>' test" in {
 		val parsed = new LispParser("(> 0 999)").SExprComplete.run()
-		testSuccessfulEval(parsed, Complete(Right((false, Map()))), empty)
+		testSuccessfulEval(parsed, Right((false, Map())), empty)
 	}		
 
 	"The Lisp Interpretter" should "return the sum of numbers when using '+'" in {
 		val parsed = new LispParser("(+ 0 1 2 3 0)").SExprComplete.run()
-		testSuccessfulEval(parsed, Complete(Right((6, Map()))), empty)
+		testSuccessfulEval(parsed, Right((6, Map())), empty)
 	}	
 
 	"The Lisp Interpretter" should "return true for a '='' test" in {
 		val parsed = new LispParser("(= 65 65)").SExprComplete.run()
-		testSuccessfulEval(parsed, Complete(Right(((true, Map())))), empty)
+		testSuccessfulEval(parsed, Right(((true, Map()))), empty)
 	}			
 
 	"The Lisp Interpretter" should "return false for a '='' test" in {
 		val parsed = new LispParser("(= 65 999)").SExprComplete.run()
-		testSuccessfulEval(parsed, Complete(Right(((false, Map())))), empty)
+		testSuccessfulEval(parsed, Right(((false, Map()))), empty)
 	}				
 
 	"The Lisp Interpretter" should "return false for '>' when strictly increasing" in {
 		val parsed = new LispParser("(> 10 20 30 1000)").SExprComplete.run()
-		testSuccessfulEval(parsed, Complete(Right(((false, Map())))), empty)
+		testSuccessfulEval(parsed, Right(((false, Map()))), empty)
 	}	
 
 
 	"The Lisp Interpretter" should "return true for '>' when strictly decreasing" in {
 		val parsed = new LispParser("(> 10 9 8 7 0)").SExprComplete.run()
-		testSuccessfulEval(parsed, Complete(Right(((true, Map())))), empty)
+		testSuccessfulEval(parsed, Right(((true, Map()))), empty)
 	}
 
 	"The Lisp Interpretter" should "return a ProcError for a parenthesized Number" in {
 		val parsed = new LispParser("((((1234))))").SExprComplete.run()
-		parsed.foreach({ x =>
-			assert( LispInterpretter.evaluate(x)(empty) == Complete(Left((ProcError, Map()))) )
-		})
+		testSuccessfulEval(parsed, Left((ProcError(""), Map())), empty)
 	}			
 
 	"The Lisp Interpretter" should "handle 'if' statements when condition evaluates to false" in {
 		val parsed = new LispParser("(if (> 10 20) (+ 1 1) (+ 3 3))").SExprComplete.run()
-		testSuccessfulEval(parsed, Complete(Right(((6, Map())))), empty)
+		testSuccessfulEval(parsed, Right(((6, Map()))), empty)
 	}		
 
 	"The Lisp Interpretter" should "return a ProcError for an SExpr beginning with two open parens" in {
 		val parsed = new LispParser("((if (> 10 20) (+ 1 1) (+ 3 3)))").SExprComplete.run()
 		val evalResult = LispInterpretter.evaluate(parsed.get)(empty)
-		testSuccessfulEval(parsed, Complete(Left((ProcError, Map()))), empty)
+		testSuccessfulEval(parsed, Left((ProcError(""), Map())), empty)
 	}		
 
 	"The Lisp Interpretter" should "handle 'if' statements when condition evaluates to true" in {
 		val parsed = new LispParser("(if (> 50 20) (+ 1 1) (+ 3 3))").SExprComplete.run()
 		val evalResult = LispInterpretter.evaluate(parsed.get)(empty)
-		testSuccessfulEval(parsed, Complete(Right(((Val(2), Map())))), empty)
+		testSuccessfulEval(parsed, Right(((Val(2), Map()))), empty)
 	}
 
 	"The Lisp Interpretter" should "print out the un-evaluated expression for the 'quote' keyword" in {
 		val parsed = new LispParser("(quote (+ 10 20))").SExprComplete.run()
 		val evalResult = LispInterpretter.evaluate(parsed.get)(empty)
-		testSuccessfulEval(parsed, Complete(Right(("(+ 10 20)", Map()))), empty)
+		testSuccessfulEval(parsed, Right(("(+ 10 20)", Map())), empty)
 	}	
 
 	"The Lisp Interpretter" should "print out the un-evaluated expression for the 'quote' keyword #2" in {
 		val parsed = new LispParser("(quote \"555foobar\")").SExprComplete.run()
 		val evalResult = LispInterpretter.evaluate(parsed.get)(empty)
-		testSuccessfulEval(parsed, Complete(Right(("\"555foobar\"", Map()))), empty)
+		testSuccessfulEval(parsed, Right(("\"555foobar\"", Map())), empty)
 	}		
 
 	"The Lisp Interpretter" should "print out the un-evaluated expression for the 'quote' keyword #3" in {
 		val parsed = new LispParser("(quote (+ 10 (+ 3 4)))").SExprComplete.run()
 		val evalResult = LispInterpretter.evaluate(parsed.get)(empty)
-		testSuccessfulEval(parsed, Complete(Right(("(+ 10 (+ 3 4))", Map()))), empty)
+		testSuccessfulEval(parsed, Right(("(+ 10 (+ 3 4))", Map())), empty)
 	}			
 
 	"The Lisp Interpretter" should "fail an 'if-statement' if the condition is a 'quote'" in {
 		val parsed = new LispParser("(if (quote 100) 555 666)").SExprComplete.run()
 		val evalResult = LispInterpretter.evaluate(parsed.get)(empty)
-		testSuccessfulEval(parsed, Complete(Left((BadIfError, Map()))), empty)
+		testSuccessfulEval(parsed, Left((BadIfResultError("100"), Map())), empty)
 	}	
 
 	"The Lisp Interpretter" should "succeeed for an 'if-statement' if the condition evaluates to true," + 
 		"and the consequential action is a quote " in {
 		val parsed = new LispParser("(if (= 0 0) (quote 555) 666)").SExprComplete.run()
 		val evalResult = LispInterpretter.evaluate(parsed.get)(empty)
-		testSuccessfulEval(parsed, Complete(Right((Val("555"), Map()))), empty)
+		testSuccessfulEval(parsed, Right((Val("555"), Map())), empty)
 	}	
 
 	"The Lisp Interpretter" should "succeed for a valid 'set!' statement expression + expression using it" in {
 		val parsed = new LispParser("(set! x 100)").SExprComplete.run()
 		val parsed2 = new LispParser("x").SExprComplete.run()
-		testSuccessfulEval(parsed, Complete(Right((Val(SetOp("x",100)),Map("x" -> Val(100))))), empty) 
-		testSuccessfulEval(parsed2, Complete(Right((Val(100), Map("x" -> Val(100))))), Map("x" -> Val(100)))
+		testSuccessfulEval(parsed, Right((Val(SetOp("x",100)),Map("x" -> Val(100)))), empty) 
+		testSuccessfulEval(parsed2, Right((Val(100), Map("x" -> Val(100)))), Map("x" -> Val(100)))
 	}	
 
 	"The Lisp Interpretter" should "succeed for a valid 'set!' statement expression + expression using it #2" in {
 		val parsed = new LispParser("(set! x 100)").SExprComplete.run()
 		val parsed2 = new LispParser("(+ x 2)").SExprComplete.run()
-		testSuccessfulEval(parsed, Complete(Right(SetOp("x",100), Map("x" -> Val(100)))), empty)
-		testSuccessfulEval(parsed2, Complete(Right((Val(102), Map("x" -> Val(100))))), Map("x" -> Val(100)))
+		testSuccessfulEval(parsed, Right(SetOp("x",100), Map("x" -> Val(100))), empty)
+		testSuccessfulEval(parsed2, Right((Val(102), Map("x" -> Val(100)))), Map("x" -> Val(100)))
 	}		
 
 	"The Lisp Interpretter" should "succeed for a valid 'set!' SExpression that has multiple parentheses" in {
 		val parsed = new LispParser("(set! x (+ (+ 0 100) 1 2))").SExprComplete.run()
-		testSuccessfulEval(parsed, Complete(Right((SetOp("x",103),Map("x" -> Val(103))))), empty)
+		testSuccessfulEval(parsed, Right((SetOp("x",103),Map("x" -> Val(103)))), empty)
 	}			
 
 	"The Lisp Interpretter" should "fail for an invalid 'set!' SExpression that has multiple parentheses" in {
@@ -155,86 +154,86 @@ class LispInterpretterTest extends FlatSpec {
 
 	"The Lisp Interpretter" should "succeed for define-ing, and then using, a Lambda." in {
 		val parsed            = new LispParser("(define f (lambda (x) (+ x x)))").SExprComplete.run()
-		val evald: EvalResult = LispInterpretter.evaluate(parsed.get)(empty)
-		val newMap: M         = evald match { case Complete(Right((_, m))) => m }
+		val evald: Either[(LispError, M), (MValue, M)] = LispInterpretter.evaluate(parsed.get)(empty)
+		val newMap: M         = evald match { case Right((_, m)) => m }
 		val parsed2           = new LispParser("(f 10)").SExprComplete.run()
-		testSuccessfulEval(parsed2, Complete(Right((Val(20),newMap))), newMap)
+		testSuccessfulEval(parsed2, Right((Val(20),newMap)), newMap)
 	}		
 
 	"The Lisp Interpretter" should "succeed for define-ing 2 lambas, and then adding them." in {
 		val parsed             = new LispParser("(define f (lambda (x) (+ x x)))").SExprComplete.run()
-		val evald: EvalResult  = LispInterpretter.evaluate(parsed.get)(empty)
-		val mapWithF: M        = evald match { case Complete(Right((_, m))) => m }
+		val evald: Either[(LispError, M), (MValue, M)]  = LispInterpretter.evaluate(parsed.get)(empty)
+		val mapWithF: M        = evald match { case Right((_, m)) => m }
 
 		val parsed2             = new LispParser("(define g (lambda (x) (+ x 3 4)))").SExprComplete.run()
-		val evald2: EvalResult = LispInterpretter.evaluate(parsed2.get)(mapWithF)
-		val mapWithBoth: M     = evald2 match { case Complete(Right((_, m))) => m }
+		val evald2: Either[(LispError, M), (MValue, M)] = LispInterpretter.evaluate(parsed2.get)(mapWithF)
+		val mapWithBoth: M     = evald2 match { case Right((_, m)) => m }
 
 		println("mapWithBoth: " + mapWithBoth)
 
 		val addLambdas            = new LispParser("(+ (f 10) (g 2))").SExprComplete.run()
-		testSuccessfulEval(addLambdas, Complete(Right((Val(29),mapWithBoth))), mapWithBoth)
+		testSuccessfulEval(addLambdas, Right((Val(29),mapWithBoth)), mapWithBoth)
 	}	
 
 	"The Lisp Interpretter" should "succeed for define-ing 2 lambas, and then comparing them for equality" in {
 		val parsed             = new LispParser("(define f (lambda (x) (+ x x)))").SExprComplete.run()
-		val evald: EvalResult  = LispInterpretter.evaluate(parsed.get)(empty)
-		val mapWithF: M        = evald match { case Complete(Right((_, m))) => m }
+		val evald: Either[(LispError, M), (MValue, M)]  = LispInterpretter.evaluate(parsed.get)(empty)
+		val mapWithF: M        = evald match { case Right((_, m)) => m }
 
 		val parsed2             = new LispParser("(define g (lambda (x) (+ x 3 4)))").SExprComplete.run()
-		val evald2: EvalResult = LispInterpretter.evaluate(parsed2.get)(mapWithF)
-		val mapWithBoth: M     = evald2 match { case Complete(Right((_, m))) => m }
+		val evald2: Either[(LispError, M), (MValue, M)] = LispInterpretter.evaluate(parsed2.get)(mapWithF)
+		val mapWithBoth: M     = evald2 match { case Right((_, m)) => m }
 
 		println("mapWithBoth: " + mapWithBoth)
 
 		val addLambdas            = new LispParser("(= (f 10) (g 2))").SExprComplete.run()
-		testSuccessfulEval(addLambdas, Complete(Right((Val(false),mapWithBoth))), mapWithBoth)
+		testSuccessfulEval(addLambdas, Right((Val(false),mapWithBoth)), mapWithBoth)
 	}	
 
 	"The Lisp Interpretter" should "succeed for define-ing 2 lambdas, and then comparing them for equality #2" in {
 		val parsed             = new LispParser("(define f (lambda (x) (+ x x)))").SExprComplete.run()
-		val evald: EvalResult  = LispInterpretter.evaluate(parsed.get)(empty)
-		val mapWithF: M        = evald match { case Complete(Right((_, m))) => m }
+		val evald: Either[(LispError, M), (MValue, M)]  = LispInterpretter.evaluate(parsed.get)(empty)
+		val mapWithF: M        = evald match { case Right((_, m)) => m }
 
 		val parsed2             = new LispParser("(define g (lambda (x) 20))").SExprComplete.run()
-		val evald2: EvalResult = LispInterpretter.evaluate(parsed2.get)(mapWithF)
-		val mapWithBoth: M     = evald2 match { case Complete(Right((_, m))) => m }
+		val evald2: Either[(LispError, M), (MValue, M)] = LispInterpretter.evaluate(parsed2.get)(mapWithF)
+		val mapWithBoth: M     = evald2 match { case Right((_, m)) => m }
 
 		println("mapWithBoth: " + mapWithBoth)
 
 		val addLambdas            = new LispParser("(= (f 10) (g 2))").SExprComplete.run()
-		testSuccessfulEval(addLambdas, Complete(Right((true,mapWithBoth))), mapWithBoth)
+		testSuccessfulEval(addLambdas, Right((true,mapWithBoth)), mapWithBoth)
 	}		
 
 	"The Lisp Interpretter" should "succeed for defining a lambda equal to another lambda, and then invoking it" in {
 		val parsed             = new LispParser("(define f (lambda (x) (+ x x)))").SExprComplete.run()
-		val evald: EvalResult  = LispInterpretter.evaluate(parsed.get)(empty)	
-		val mapWithF: M        = evald match { case Complete(Right((_, m))) => m }
+		val evald: Either[(LispError, M), (MValue, M)]  = LispInterpretter.evaluate(parsed.get)(empty)	
+		val mapWithF: M        = evald match { case Right((_, m)) => m }
 
 		val parsed2             = new LispParser("(define g f)").SExprComplete.run()
-		val evald2: EvalResult  = LispInterpretter.evaluate(parsed2.get)(mapWithF)	
-		val mapWithBoth: M      = evald2 match { case Complete(Right((_, m))) => m }
+		val evald2: Either[(LispError, M), (MValue, M)]  = LispInterpretter.evaluate(parsed2.get)(mapWithF)	
+		val mapWithBoth: M      = evald2 match { case Right((_, m)) => m }
 
 		val parsed3             = new LispParser("(g 33)").SExprComplete.run()
-		val invoked: EvalResult = LispInterpretter.evaluate(parsed3.get)(mapWithBoth)	
-		val finalMap: M         = invoked match { case Complete(Right((_, m))) => m }
+		val invoked: Either[(LispError, M), (MValue, M)] = LispInterpretter.evaluate(parsed3.get)(mapWithBoth)	
+		val finalMap: M         = invoked match { case Right((_, m)) => m }
 
-		testSuccessfulEval(parsed3, Complete(Right((Val(66),finalMap))), mapWithBoth)
+		testSuccessfulEval(parsed3, Right((Val(66),finalMap)), mapWithBoth)
 	}
 
 	"The Lisp Interpretter" should "succeed for when applying a value to a lambda" in {
 		val parsed = new LispParser("((lambda (x) (+ 33)) 10)").SExprComplete.run()
-		testSuccessfulEval(parsed, Complete(Right((Val(33), empty))), empty)
+		testSuccessfulEval(parsed, Right((Val(33), empty)), empty)
 	}
 
 	"The Lisp Interpretter" should "succeed for when applying two values to a lambda" in {
 		val parsed = new LispParser("((lambda (x y) (+ 33 x y)) 10 20)").SExprComplete.run()
-		testSuccessfulEval(parsed, Complete(Right((Val(63), empty))), empty)
+		testSuccessfulEval(parsed, Right((Val(63), empty)), empty)
 	}	
 
 
 	def testSuccessfulEval(parsed: Try[SExpr], 
-						   expected: EvalResult, 
+						   expected: Either[(LispError, M), (MValue, M)], 
 						   map: M): Unit = parsed match {
 		case Success(e) => assert (LispInterpretter.evaluate(e)(map) == expected)
 		case Failure(_) => assert (false)


### PR DESCRIPTION
Replaced `EvalResult` with `Either` to enable for-comprehensions.

This change does not involve those for-comprehensions.
