### PR TITLE
Enable evaluation of multiple SExpressions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,6 @@ Complete(Left((NoVarExists,Map(f -> <function1>, g -> <function1>))))
 Complete(Right(((),Map(f -> <function1>, g -> <function1>, z -> 300))))
 >(g 30)
 Complete(Right((330,Map(f -> <function1>, g -> <function1>, z -> 300))))
->12341234
-Complete(Right((12341234,Map(f -> <function1>, g -> <function1>, z -> 300))))
 ```
 
 **Using `set!` with lambda**

--- a/src/main/scala/net/common/Error.scala
+++ b/src/main/scala/net/common/Error.scala
@@ -24,6 +24,5 @@ object Error {
 	case object BadLambda                                            extends InvalidLambda
 
 	sealed trait MathError 		   extends InterpretterError
-	case class NotAnInt(x: String) extends MathError
-
+	case class NotAnInt(x: String) extends MathError	
 }

--- a/src/main/scala/net/interpretter/LispInterpretter.scala
+++ b/src/main/scala/net/interpretter/LispInterpretter.scala
@@ -231,7 +231,7 @@ object LispInterpretter {
 		}
 	}
 
-	private def sndE[A, B, C, D](e: Either[(A, Map[C,D]), (B, Map[C,D])]): Map[C, D] = e match {
+    def sndE[A, B, C, D](e: Either[(A, Map[C,D]), (B, Map[C,D])]): Map[C, D] = e match {
 		case Right((_, m)) => m
 		case Left((_, m))  => m
 	}

--- a/src/main/scala/net/interpretter/LispInterpretter.scala
+++ b/src/main/scala/net/interpretter/LispInterpretter.scala
@@ -6,6 +6,21 @@ object LispInterpretter {
 	
 	import net.common.Error._
 
+	def evaluateSExprs(es: Seq[SExpr], map: M): List[Either[(LispError, M), (MValue, M)]] = {
+		val zero: (List[Either[(LispError, M), (MValue, M)]], M) = (Nil, map)
+
+		val (results, _) = 
+			es.foldLeft(zero){
+				(acc, elem) => { 
+					val (previous, m) = acc
+					val result        = LispInterpretter.evaluate(elem)(m)
+					(previous ++ List(result), sndE(result))
+			}
+		}
+
+		results
+	}
+
 	def evaluate(e: SExpr)(map: M): Either[(LispError, M), (MValue, M)] =
 		e match {
 			case Number(n) 					    => Right((Val(n), map))
@@ -215,4 +230,16 @@ object LispInterpretter {
 			}
 		}
 	}
+
+	private def sndE[A, B, C, D](e: Either[(A, Map[C,D]), (B, Map[C,D])]): Map[C, D] = e match {
+		case Right((_, m)) => m
+		case Left((_, m))  => m
+	}
+
+	// TODO: not sure if this is necessary. Returning a Left should still have the right map
+	// def getMap(res: Either[(LispError, M), (MValue, M)], previousMap: M): M = res match {
+	// 	case Right((_, m)) => m
+	// 	case Left(_)       => previousMap
+	// }	
 }
+

--- a/src/main/scala/net/parser/LispParser.scala
+++ b/src/main/scala/net/parser/LispParser.scala
@@ -13,6 +13,7 @@ class LispParser(val input: ParserInput) extends Parser {
 	import LispParser._
 
 	def SExprs: Rule1[Seq[AST.SExpr]] = rule { oneOrMore(SExpr).separatedBy(Spaces) ~ Spaces ~ EOI }
+	def OneSExpr: Rule1[AST.SExpr]    = rule { SExpr ~ Spaces ~ EOI }
 	def SExpr: Rule1[AST.SExpr]       = rule { Atom | '(' ~ oneOrMore(Comb).separatedBy(Spaces) ~ ')' ~> (_.toList) ~> (AST.Comb(_)) }
 	def Comb:  Rule1[AST.SExpr]       = rule {  Spaces ~ SExpr ~ Spaces }
 	def Atom:  Rule1[AST.Atom]        = rule { Num | Ident }

--- a/src/main/scala/net/parser/LispParser.scala
+++ b/src/main/scala/net/parser/LispParser.scala
@@ -12,17 +12,17 @@ class LispParser(val input: ParserInput) extends Parser {
 
 	import LispParser._
 
-	def SExprComplete: Rule1[AST.SExpr] = rule { SExpr ~ Spaces ~ EOI }
-	def SExpr: Rule1[AST.SExpr]         = rule { Atom | '(' ~ oneOrMore(Comb).separatedBy(Spaces) ~ ')' ~> (_.toList) ~> (AST.Comb(_)) }
-	def Comb:  Rule1[AST.SExpr]       	= rule {  Spaces ~ SExpr ~ Spaces }
-	def Atom:  Rule1[AST.Atom]        	= rule { Num | Ident }
+	def SExprs: Rule1[Seq[AST.SExpr]] = rule { oneOrMore(SExpr).separatedBy(Spaces) ~ Spaces ~ EOI }
+	def SExpr: Rule1[AST.SExpr]       = rule { Atom | '(' ~ oneOrMore(Comb).separatedBy(Spaces) ~ ')' ~> (_.toList) ~> (AST.Comb(_)) }
+	def Comb:  Rule1[AST.SExpr]       = rule {  Spaces ~ SExpr ~ Spaces }
+	def Atom:  Rule1[AST.Atom]        = rule { Num | Ident }
 
-	def Num:   Rule1[AST.Number]      	= rule { capture(Digits) ~> (_.toInt) ~> (AST.Number(_)) }
-	def Ident: Rule1[AST.Ident]       	= rule { capture(AnyString) ~> (_.toString) ~> (AST.Ident(_)) }
+	def Num:   Rule1[AST.Number]      = rule { capture(Digits) ~> (_.toInt) ~> (AST.Number(_)) }
+	def Ident: Rule1[AST.Ident]       = rule { capture(AnyString) ~> (_.toString) ~> (AST.Ident(_)) }
 	
-	def AnyString					    = rule { ("\"" ~ StringVal ~ "\"") | StringVal}
-	def StringVal 					  	= rule { oneOrMore( anyOf(lower) | anyOf(upper) | anyOf(numbers) | "!") | MathOps }
-	def MathOps						  	= rule { "+" | "-" | ">" | "<" | "=" }
-	def Digits 						  	= rule { oneOrMore(CharPredicate.Digit) }
-	def Spaces 						  	= rule { zeroOrMore(' ') }
+	def AnyString				      = rule { ("\"" ~ StringVal ~ "\"") | StringVal}
+	def StringVal 				      = rule { oneOrMore( anyOf(lower) | anyOf(upper) | anyOf(numbers) | "!") | MathOps }
+	def MathOps						  = rule { "+" | "-" | ">" | "<" | "=" }
+	def Digits 						  = rule { oneOrMore(CharPredicate.Digit) }
+	def Spaces 						  = rule { zeroOrMore(' ') }
 }

--- a/src/main/scala/net/repl/LispRepl.scala
+++ b/src/main/scala/net/repl/LispRepl.scala
@@ -8,29 +8,28 @@ import net.common.Error._
 import scala.util.{Try, Success, Failure}
 import scalaz.effect.IO
 import scalaz.effect.IO._
-import scalaz.NonEmptyList
 
 object LispRepl {
 
-	// def runForever(map: M): IO[Unit] = for {
-	// 	input  <- readLn
-	// 	_      <- putStrLn(s">$input")
-	// 	result <- IO(runSingle(input, map))
-	// 	_ 	   <- putStrLn(result.toString)
-	// 	_ 	   <- runForever(getMap(result, map))
-	// } yield ()
+	def runForever(map: M): IO[Unit] = for {
+		input  <- readLn
+		_      <- putStrLn(s">$input")
+		result <- IO(runSingle(input, map))
+		_ 	   <- putStrLn(result.toString)
+		_ 	   <- runForever(sndE(result))
+	} yield ()
 
-	// def runSingle(input: String, map: M): Either[(LispError, M), (MValue, M)] = 
-	// 	parse(input) match {
-	// 		case Success(e)  => interpret(e, map)
-	// 		case Failure(ex) => Left((ParseError(ex), map))
-	// 	}
+	def runSingle(input: String, map: M): Either[(LispError, M), (MValue, M)] = 
+		parse(input) match {
+			case Success(e)  => interpret(e, map)
+			case Failure(ex) => Left((ParseError(ex), map))
+		}
 
-	// def interpret(s: SExpr, map: M): Either[(LispError, M), (MValue, M)] = 
-	// 	LispInterpretter.evaluate(s)(map)
+	def interpret(s: SExpr, map: M): Either[(LispError, M), (MValue, M)] = 
+		LispInterpretter.evaluate(s)(map)
 
-	// def parse(x: String): Try[SExpr] = 
-	// 	new LispParser(x).SExprComplete.run() 
+	def parse(x: String): Try[SExpr] = 
+		new LispParser(x).OneSExpr.run() 
 
 	// def evalString(exprs: String, delimiter: String): Either[LispError, List[Either[(LispError, M), (MValue, M)]]] = {
 	// 	val inputs: List[String]    				     = exprs.split(delimiter)

--- a/src/main/scala/net/repl/LispRepl.scala
+++ b/src/main/scala/net/repl/LispRepl.scala
@@ -8,31 +8,59 @@ import net.common.Error._
 import scala.util.{Try, Success, Failure}
 import scalaz.effect.IO
 import scalaz.effect.IO._
+import scalaz.NonEmptyList
 
 object LispRepl {
 
-	def runForever(map: M): IO[Unit] = for {
-		input  <- readLn
-		_      <- putStrLn(s">$input")
-		result <- IO(runSingle(input, map))
-		_ 	   <- putStrLn(result.toString)
-		_ 	   <- runForever(getMap(result, map))
-	} yield ()
+	// def runForever(map: M): IO[Unit] = for {
+	// 	input  <- readLn
+	// 	_      <- putStrLn(s">$input")
+	// 	result <- IO(runSingle(input, map))
+	// 	_ 	   <- putStrLn(result.toString)
+	// 	_ 	   <- runForever(getMap(result, map))
+	// } yield ()
 
-	def runSingle(input: String, map: M): Either[(LispError, M), (MValue, M)] = 
-		parse(input) match {
-			case Success(e)  => interpret(e, map)
-			case Failure(ex) => Left((ParseError(ex), map))
-		}
+	// def runSingle(input: String, map: M): Either[(LispError, M), (MValue, M)] = 
+	// 	parse(input) match {
+	// 		case Success(e)  => interpret(e, map)
+	// 		case Failure(ex) => Left((ParseError(ex), map))
+	// 	}
 
-	def interpret(s: SExpr, map: M): Either[(LispError, M), (MValue, M)] = 
-		LispInterpretter.evaluate(s)(map)
+	// def interpret(s: SExpr, map: M): Either[(LispError, M), (MValue, M)] = 
+	// 	LispInterpretter.evaluate(s)(map)
 
-	def parse(x: String): Try[SExpr] = 
-		new LispParser(x).SExprComplete.run() 
-	
-	def getMap(res: Either[(LispError, M), (MValue, M)], previousMap: M): M = res match {
-		case Right((_, m)) => m
-		case Left(_)       => previousMap
-	}
+	// def parse(x: String): Try[SExpr] = 
+	// 	new LispParser(x).SExprComplete.run() 
+
+	// def evalString(exprs: String, delimiter: String): Either[LispError, List[Either[(LispError, M), (MValue, M)]]] = {
+	// 	val inputs: List[String]    				     = exprs.split(delimiter)
+	// 	val parsed: List[Try[SExpr]] 				  	 = inputs.map(new LispParser(_).SExprComplete.run())
+	// 	val collected: (List[LispError], List[SExpr])    = getParsedResult(parsed)
+	// 	val result: Either[List[LispError], List[SExpr]] = collected match {
+	// 		case (Nil, xs) => Right(xs)
+	// 		case (xs, _ )  => Left(xs)
+	// 	}
+	// 	g(result)
+	// }
+
+	// def g(parsed: Either[List[LispError], List[SExpr]]): Either[LispError, List[Either[(LispError, M), (MValue, M)]]] = {
+	// 	lazy val accumulator: (M, List[MValue], MValue) = (Map(), )
+
+	// 	parsed match {
+	// 		case Right(es)      => es.foldLeft()
+	// 		case Left(err :: _) => Left(err)
+	// 		//case Left(Nil)      => // use scalaz NonEmptyList?
+	// 	}
+	// }
+
+	// private def getParsedResult(parsed: List[Try[SExpr]]): (List[LispError], List[SExpr]) = 
+	// 	parsed.foldRight(List[SExpr]()) {
+	// 		(parsed, acc) => {
+	// 			val (errs, es) = acc
+	// 			parsed match {
+	// 				case Failure(ex) => (ParseError(ex) :: errs, es)
+	// 				case Success(e)  => (errs, e :: es)
+	// 			}
+	// 		}
+	// 	}
 }

--- a/src/test/scala/net/interpretter/LispInterpretterTest.scala
+++ b/src/test/scala/net/interpretter/LispInterpretterTest.scala
@@ -5,7 +5,6 @@ import net.parser.LispParser
 import net.parser.AST._
 import net.interpretter.LispInterpretter._
 import net.common.Error._
-import net.repl.LispRepl.getMap
 import scala.util.{Try, Success, Failure}
 
 class LispInterpretterTest extends FlatSpec {
@@ -16,233 +15,230 @@ class LispInterpretterTest extends FlatSpec {
 	implicit def anyToSingleValue(x: Any): SingleValue = Val(x)
 
 	"The Lisp Interpretter" should "return the number itself for a Number" in {
-		val parsed = new LispParser("5").SExprComplete.run()
-		testSuccessfulEval(parsed, Right((5, empty)), empty)
+		val parsed = new LispParser("5").SExprs.run().get.head
+		testSuccessfulEvalSingle(parsed, Right((5, empty)), empty)
 	}
 
 	"The Lisp Interpretter" should "return the string literal itself for an Ident" in {
-		val parsed = new LispParser("\"foo3\"").SExprComplete.run()
-		testSuccessfulEval(parsed, Right(("\"foo3\"", empty)), empty)
+		val parsed = new LispParser("\"foo3\"").SExprs.run().get.head
+		testSuccessfulEvalSingle(parsed, Right(("\"foo3\"", empty)), empty)
 	}	
 
 	"The Lisp Interpretter" should "return the variable's value for an existing variable" in {
-		val parsed = new LispParser("x").SExprComplete.run()
+		val parsed = new LispParser("x").SExprs.run().get.head
 		val map = Map("x" -> Val(456))
-		testSuccessfulEval(parsed, Right(((Val(456), map))), map)
+		testSuccessfulEvalSingle(parsed, Right(((Val(456), map))), map)
 	}	
 
 	"The Lisp Interpretter" should "fail for a non-existing variable" in {
-		val parsed = new LispParser("x").SExprComplete.run()
-		testSuccessfulEval(parsed, Left((NoVarExists("x"), Map())), empty)
+		val parsed = new LispParser("x").SExprs.run().get.head
+		testSuccessfulEvalSingle(parsed, Left((NoVarExists("x"), Map())), empty)
 	}		
 
 	"The Lisp Interpretter" should "return true for a '>' test" in {
-		val parsed = new LispParser("(> 1000 1)").SExprComplete.run()
-		testSuccessfulEval(parsed, Right(((true, Map()))), empty)
+		val parsed = new LispParser("(> 1000 1)").SExprs.run().get.head
+		testSuccessfulEvalSingle(parsed, Right(((true, Map()))), empty)
 	}		
 
 	"The Lisp Interpretter" should "return false for a '>' test" in {
-		val parsed = new LispParser("(> 0 999)").SExprComplete.run()
-		testSuccessfulEval(parsed, Right((false, Map())), empty)
+		val parsed = new LispParser("(> 0 999)").SExprs.run().get.head
+		testSuccessfulEvalSingle(parsed, Right((false, Map())), empty)
 	}		
 
 	"The Lisp Interpretter" should "return the sum of numbers when using '+'" in {
-		val parsed = new LispParser("(+ 0 1 2 3 0)").SExprComplete.run()
-		testSuccessfulEval(parsed, Right((6, Map())), empty)
+		val parsed = new LispParser("(+ 0 1 2 3 0)").SExprs.run().get.head
+		testSuccessfulEvalSingle(parsed, Right((6, Map())), empty)
 	}	
 
 	"The Lisp Interpretter" should "return true for a '='' test" in {
-		val parsed = new LispParser("(= 65 65)").SExprComplete.run()
-		testSuccessfulEval(parsed, Right(((true, Map()))), empty)
+		val parsed = new LispParser("(= 65 65)").SExprs.run().get.head
+		testSuccessfulEvalSingle(parsed, Right(((true, Map()))), empty)
 	}			
 
 	"The Lisp Interpretter" should "return false for a '='' test" in {
-		val parsed = new LispParser("(= 65 999)").SExprComplete.run()
-		testSuccessfulEval(parsed, Right(((false, Map()))), empty)
+		val parsed = new LispParser("(= 65 999)").SExprs.run().get.head
+		testSuccessfulEvalSingle(parsed, Right(((false, Map()))), empty)
 	}				
 
 	"The Lisp Interpretter" should "return false for '>' when strictly increasing" in {
-		val parsed = new LispParser("(> 10 20 30 1000)").SExprComplete.run()
-		testSuccessfulEval(parsed, Right(((false, Map()))), empty)
+		val parsed = new LispParser("(> 10 20 30 1000)").SExprs.run().get.head
+		testSuccessfulEvalSingle(parsed, Right(((false, Map()))), empty)
 	}	
 
 
 	"The Lisp Interpretter" should "return true for '>' when strictly decreasing" in {
-		val parsed = new LispParser("(> 10 9 8 7 0)").SExprComplete.run()
-		testSuccessfulEval(parsed, Right(((true, Map()))), empty)
+		val parsed = new LispParser("(> 10 9 8 7 0)").SExprs.run().get.head
+		testSuccessfulEvalSingle(parsed, Right(((true, Map()))), empty)
 	}
 
 	"The Lisp Interpretter" should "return a ProcError for a parenthesized Number" in {
-		val parsed = new LispParser("((((1234))))").SExprComplete.run()
-		testSuccessfulEval(parsed, Left((ProcError(""), Map())), empty)
+		val parsed = new LispParser("((((1234))))").SExprs.run().get.head
+		testSuccessfulEvalSingle(parsed, Left((ProcError(""), Map())), empty)
 	}			
 
 	"The Lisp Interpretter" should "handle 'if' statements when condition evaluates to false" in {
-		val parsed = new LispParser("(if (> 10 20) (+ 1 1) (+ 3 3))").SExprComplete.run()
-		testSuccessfulEval(parsed, Right(((6, Map()))), empty)
+		val parsed = new LispParser("(if (> 10 20) (+ 1 1) (+ 3 3))").SExprs.run().get.head
+		testSuccessfulEvalSingle(parsed, Right(((6, Map()))), empty)
 	}		
 
 	"The Lisp Interpretter" should "return a ProcError for an SExpr beginning with two open parens" in {
-		val parsed = new LispParser("((if (> 10 20) (+ 1 1) (+ 3 3)))").SExprComplete.run()
-		val evalResult = LispInterpretter.evaluate(parsed.get)(empty)
-		testSuccessfulEval(parsed, Left((ProcError(""), Map())), empty)
+		val parsed = new LispParser("((if (> 10 20) (+ 1 1) (+ 3 3)))").SExprs.run().get.head
+		val evalResult = LispInterpretter.evaluate(parsed)(empty)
+		testSuccessfulEvalSingle(parsed, Left((ProcError(""), Map())), empty)
 	}		
 
 	"The Lisp Interpretter" should "handle 'if' statements when condition evaluates to true" in {
-		val parsed = new LispParser("(if (> 50 20) (+ 1 1) (+ 3 3))").SExprComplete.run()
-		val evalResult = LispInterpretter.evaluate(parsed.get)(empty)
-		testSuccessfulEval(parsed, Right(((Val(2), Map()))), empty)
+		val parsed = new LispParser("(if (> 50 20) (+ 1 1) (+ 3 3))").SExprs.run().get.head
+		val evalResult = LispInterpretter.evaluate(parsed)(empty)
+		testSuccessfulEvalSingle(parsed, Right(((Val(2), Map()))), empty)
 	}
 
 	"The Lisp Interpretter" should "print out the un-evaluated expression for the 'quote' keyword" in {
-		val parsed = new LispParser("(quote (+ 10 20))").SExprComplete.run()
-		val evalResult = LispInterpretter.evaluate(parsed.get)(empty)
-		testSuccessfulEval(parsed, Right(("(+ 10 20)", Map())), empty)
+		val parsed = new LispParser("(quote (+ 10 20))").SExprs.run().get.head
+		val evalResult = LispInterpretter.evaluate(parsed)(empty)
+		testSuccessfulEvalSingle(parsed, Right(("(+ 10 20)", Map())), empty)
 	}	
 
 	"The Lisp Interpretter" should "print out the un-evaluated expression for the 'quote' keyword #2" in {
-		val parsed = new LispParser("(quote \"555foobar\")").SExprComplete.run()
-		val evalResult = LispInterpretter.evaluate(parsed.get)(empty)
-		testSuccessfulEval(parsed, Right(("\"555foobar\"", Map())), empty)
+		val parsed = new LispParser("(quote \"555foobar\")").SExprs.run().get.head
+		val evalResult = LispInterpretter.evaluate(parsed)(empty)
+		testSuccessfulEvalSingle(parsed, Right(("\"555foobar\"", Map())), empty)
 	}		
 
 	"The Lisp Interpretter" should "print out the un-evaluated expression for the 'quote' keyword #3" in {
-		val parsed = new LispParser("(quote (+ 10 (+ 3 4)))").SExprComplete.run()
-		val evalResult = LispInterpretter.evaluate(parsed.get)(empty)
-		testSuccessfulEval(parsed, Right(("(+ 10 (+ 3 4))", Map())), empty)
+		val parsed = new LispParser("(quote (+ 10 (+ 3 4)))").SExprs.run().get.head
+		val evalResult = LispInterpretter.evaluate(parsed)(empty)
+		testSuccessfulEvalSingle(parsed, Right(("(+ 10 (+ 3 4))", Map())), empty)
 	}			
 
 	"The Lisp Interpretter" should "fail an 'if-statement' if the condition is a 'quote'" in {
-		val parsed = new LispParser("(if (quote 100) 555 666)").SExprComplete.run()
-		val evalResult = LispInterpretter.evaluate(parsed.get)(empty)
-		testSuccessfulEval(parsed, Left((BadIfResultError("100"), Map())), empty)
+		val parsed = new LispParser("(if (quote 100) 555 666)").SExprs.run().get.head
+		val evalResult = LispInterpretter.evaluate(parsed)(empty)
+		testSuccessfulEvalSingle(parsed, Left((BadIfResultError("100"), Map())), empty)
 	}	
 
 	"The Lisp Interpretter" should "succeeed for an 'if-statement' if the condition evaluates to true," + 
 		"and the consequential action is a quote " in {
-		val parsed = new LispParser("(if (= 0 0) (quote 555) 666)").SExprComplete.run()
-		val evalResult = LispInterpretter.evaluate(parsed.get)(empty)
-		testSuccessfulEval(parsed, Right((Val("555"), Map())), empty)
+		val parsed = new LispParser("(if (= 0 0) (quote 555) 666)").SExprs.run().get.head
+		val evalResult = LispInterpretter.evaluate(parsed)(empty)
+		testSuccessfulEvalSingle(parsed, Right((Val("555"), Map())), empty)
 	}	
 
 	"The Lisp Interpretter" should "succeed for a valid 'set!' statement expression + expression using it" in {
-		val parsed = new LispParser("(set! x 100)").SExprComplete.run()
-		val parsed2 = new LispParser("x").SExprComplete.run()
-		testSuccessfulEval(parsed, Right((Val(SetOp("x",100)),Map("x" -> Val(100)))), empty) 
-		testSuccessfulEval(parsed2, Right((Val(100), Map("x" -> Val(100)))), Map("x" -> Val(100)))
+		val parsed = new LispParser("(set! x 100)").SExprs.run().get.head
+		val parsed2 = new LispParser("x").SExprs.run().get.head
+		testSuccessfulEvalSingle(parsed, Right((Val(SetOp("x",100)),Map("x" -> Val(100)))), empty) 
+		testSuccessfulEvalSingle(parsed2, Right((Val(100), Map("x" -> Val(100)))), Map("x" -> Val(100)))
 	}	
 
 	"The Lisp Interpretter" should "succeed for a valid 'set!' statement expression + expression using it #2" in {
-		val parsed = new LispParser("(set! x 100)").SExprComplete.run()
-		val parsed2 = new LispParser("(+ x 2)").SExprComplete.run()
-		testSuccessfulEval(parsed, Right(SetOp("x",100), Map("x" -> Val(100))), empty)
-		testSuccessfulEval(parsed2, Right((Val(102), Map("x" -> Val(100)))), Map("x" -> Val(100)))
+		val parsed = new LispParser("(set! x 100)").SExprs.run().get.head
+		val parsed2 = new LispParser("(+ x 2)").SExprs.run().get.head
+		testSuccessfulEvalSingle(parsed, Right(SetOp("x",100), Map("x" -> Val(100))), empty)
+		testSuccessfulEvalSingle(parsed2, Right((Val(102), Map("x" -> Val(100)))), Map("x" -> Val(100)))
 	}		
 
 	"The Lisp Interpretter" should "succeed for a valid 'set!' SExpression that has multiple parentheses" in {
-		val parsed = new LispParser("(set! x (+ (+ 0 100) 1 2))").SExprComplete.run()
-		testSuccessfulEval(parsed, Right((SetOp("x",103),Map("x" -> Val(103)))), empty)
+		val parsed = new LispParser("(set! x (+ (+ 0 100) 1 2))").SExprs.run().get.head
+		testSuccessfulEvalSingle(parsed, Right((SetOp("x",103),Map("x" -> Val(103)))), empty)
 	}			
 
-	"The Lisp Interpretter" should "fail for an invalid 'set!' SExpression that has multiple parentheses" in {
-		val parsed = new LispParser("(set! x (+ (+ 0 100) 1 2)) BLEEP BLAH").SExprComplete.run()
-		parsed match {
-			case Failure(_) => assert (true)
-			case _ 			=> assert (false)
-		}
+	"The Lisp Interpretter" should "parse, but fail to evaluate the last proc call to a non-existent variable/function." in {
+		val parsed = new LispParser("(set! x (+ (+ 0 100) 1 2)) BLEEP").SExprs.run()
+		val evald = evaluateSExprs(parsed.get.toList, empty)
+		val expected = Right((Val(SetOp("x",103)),Map("x" -> Val(103)))) :: Left((NoVarExists("BLEEP"), Map("x" -> Val(103)))) :: Nil
+		assert(evald == expected)
 	}				
 
 	"The Lisp Interpretter" should "succeed for define-ing, and then using, a Lambda." in {
-		val parsed            = new LispParser("(define f (lambda (x) (+ x x)))").SExprComplete.run()
-		val evald: Either[(LispError, M), (MValue, M)] = LispInterpretter.evaluate(parsed.get)(empty)
+		val parsed            = new LispParser("(define f (lambda (x) (+ x x)))").SExprs.run().get.head
+		val evald: Either[(LispError, M), (MValue, M)] = LispInterpretter.evaluate(parsed)(empty)
 		val newMap: M         = evald match { case Right((_, m)) => m }
-		val parsed2           = new LispParser("(f 10)").SExprComplete.run()
-		testSuccessfulEval(parsed2, Right((Val(20),newMap)), newMap)
+		val parsed2           = new LispParser("(f 10)").SExprs.run().get.head
+		testSuccessfulEvalSingle(parsed2, Right((Val(20),newMap)), newMap)
 	}		
 
 	"The Lisp Interpretter" should "succeed for define-ing 2 lambas, and then adding them." in {
-		val parsed             = new LispParser("(define f (lambda (x) (+ x x)))").SExprComplete.run()
-		val evald: Either[(LispError, M), (MValue, M)]  = LispInterpretter.evaluate(parsed.get)(empty)
+		val parsed             = new LispParser("(define f (lambda (x) (+ x x)))").SExprs.run().get.head
+		val evald: Either[(LispError, M), (MValue, M)]  = LispInterpretter.evaluate(parsed)(empty)
 		val mapWithF: M        = evald match { case Right((_, m)) => m }
 
-		val parsed2             = new LispParser("(define g (lambda (x) (+ x 3 4)))").SExprComplete.run()
-		val evald2: Either[(LispError, M), (MValue, M)] = LispInterpretter.evaluate(parsed2.get)(mapWithF)
+		val parsed2             = new LispParser("(define g (lambda (x) (+ x 3 4)))").SExprs.run().get.head
+		val evald2: Either[(LispError, M), (MValue, M)] = LispInterpretter.evaluate(parsed2)(mapWithF)
 		val mapWithBoth: M     = evald2 match { case Right((_, m)) => m }
 
 		println("mapWithBoth: " + mapWithBoth)
 
-		val addLambdas            = new LispParser("(+ (f 10) (g 2))").SExprComplete.run()
-		testSuccessfulEval(addLambdas, Right((Val(29),mapWithBoth)), mapWithBoth)
+		val addLambdas            = new LispParser("(+ (f 10) (g 2))").SExprs.run().get.head
+		testSuccessfulEvalSingle(addLambdas, Right((Val(29),mapWithBoth)), mapWithBoth)
 	}	
 
 	"The Lisp Interpretter" should "succeed for define-ing 2 lambas, and then comparing them for equality" in {
-		val parsed             = new LispParser("(define f (lambda (x) (+ x x)))").SExprComplete.run()
-		val evald: Either[(LispError, M), (MValue, M)]  = LispInterpretter.evaluate(parsed.get)(empty)
+		val parsed             = new LispParser("(define f (lambda (x) (+ x x)))").SExprs.run().get.head
+		val evald: Either[(LispError, M), (MValue, M)]  = LispInterpretter.evaluate(parsed)(empty)
 		val mapWithF: M        = evald match { case Right((_, m)) => m }
 
-		val parsed2             = new LispParser("(define g (lambda (x) (+ x 3 4)))").SExprComplete.run()
-		val evald2: Either[(LispError, M), (MValue, M)] = LispInterpretter.evaluate(parsed2.get)(mapWithF)
+		val parsed2             = new LispParser("(define g (lambda (x) (+ x 3 4)))").SExprs.run().get.head
+		val evald2: Either[(LispError, M), (MValue, M)] = LispInterpretter.evaluate(parsed2)(mapWithF)
 		val mapWithBoth: M     = evald2 match { case Right((_, m)) => m }
 
 		println("mapWithBoth: " + mapWithBoth)
 
-		val addLambdas            = new LispParser("(= (f 10) (g 2))").SExprComplete.run()
-		testSuccessfulEval(addLambdas, Right((Val(false),mapWithBoth)), mapWithBoth)
+		val addLambdas            = new LispParser("(= (f 10) (g 2))").SExprs.run().get.head
+		testSuccessfulEvalSingle(addLambdas, Right((Val(false),mapWithBoth)), mapWithBoth)
 	}	
 
 	"The Lisp Interpretter" should "succeed for define-ing 2 lambdas, and then comparing them for equality #2" in {
-		val parsed             = new LispParser("(define f (lambda (x) (+ x x)))").SExprComplete.run()
-		val evald: Either[(LispError, M), (MValue, M)]  = LispInterpretter.evaluate(parsed.get)(empty)
+		val parsed             = new LispParser("(define f (lambda (x) (+ x x)))").SExprs.run().get.head
+		val evald: Either[(LispError, M), (MValue, M)]  = LispInterpretter.evaluate(parsed)(empty)
 		val mapWithF: M        = evald match { case Right((_, m)) => m }
 
-		val parsed2             = new LispParser("(define g (lambda (x) 20))").SExprComplete.run()
-		val evald2: Either[(LispError, M), (MValue, M)] = LispInterpretter.evaluate(parsed2.get)(mapWithF)
+		val parsed2             = new LispParser("(define g (lambda (x) 20))").SExprs.run().get.head
+		val evald2: Either[(LispError, M), (MValue, M)] = LispInterpretter.evaluate(parsed2)(mapWithF)
 		val mapWithBoth: M     = evald2 match { case Right((_, m)) => m }
 
 		println("mapWithBoth: " + mapWithBoth)
 
-		val addLambdas            = new LispParser("(= (f 10) (g 2))").SExprComplete.run()
-		testSuccessfulEval(addLambdas, Right((true,mapWithBoth)), mapWithBoth)
+		val addLambdas            = new LispParser("(= (f 10) (g 2))").SExprs.run().get.head
+		testSuccessfulEvalSingle(addLambdas, Right((true,mapWithBoth)), mapWithBoth)
 	}		
 
 	"The Lisp Interpretter" should "succeed for defining a lambda equal to another lambda, and then invoking it" in {
-		val parsed             = new LispParser("(define f (lambda (x) (+ x x)))").SExprComplete.run()
-		val evald: Either[(LispError, M), (MValue, M)]  = LispInterpretter.evaluate(parsed.get)(empty)	
+		val parsed             = new LispParser("(define f (lambda (x) (+ x x)))").SExprs.run().get.head
+		val evald: Either[(LispError, M), (MValue, M)]  = LispInterpretter.evaluate(parsed)(empty)	
 		val mapWithF: M        = evald match { case Right((_, m)) => m }
 
-		val parsed2             = new LispParser("(define g f)").SExprComplete.run()
-		val evald2: Either[(LispError, M), (MValue, M)]  = LispInterpretter.evaluate(parsed2.get)(mapWithF)	
+		val parsed2             = new LispParser("(define g f)").SExprs.run().get.head
+		val evald2: Either[(LispError, M), (MValue, M)]  = LispInterpretter.evaluate(parsed2)(mapWithF)	
 		val mapWithBoth: M      = evald2 match { case Right((_, m)) => m }
 
-		val parsed3             = new LispParser("(g 33)").SExprComplete.run()
-		val invoked: Either[(LispError, M), (MValue, M)] = LispInterpretter.evaluate(parsed3.get)(mapWithBoth)	
+		val parsed3             = new LispParser("(g 33)").SExprs.run().get.head
+		val invoked: Either[(LispError, M), (MValue, M)] = LispInterpretter.evaluate(parsed3)(mapWithBoth)	
 		val finalMap: M         = invoked match { case Right((_, m)) => m }
 
-		testSuccessfulEval(parsed3, Right((Val(66),finalMap)), mapWithBoth)
+		testSuccessfulEvalSingle(parsed3, Right((Val(66),finalMap)), mapWithBoth)
 	}
 
 	"The Lisp Interpretter" should "succeed for when applying a value to a lambda" in {
-		val parsed = new LispParser("((lambda (x) (+ 33)) 10)").SExprComplete.run()
-		testSuccessfulEval(parsed, Right((Val(33), empty)), empty)
+		val parsed = new LispParser("((lambda (x) (+ 33)) 10)").SExprs.run().get.head
+		testSuccessfulEvalSingle(parsed, Right((Val(33), empty)), empty)
 	}
 
 	"The Lisp Interpretter" should "succeed for when applying two values to a lambda" in {
-		val parsed = new LispParser("((lambda (x y) (+ 33 x y)) 10 20)").SExprComplete.run()
-		testSuccessfulEval(parsed, Right((Val(63), empty)), empty)
+		val parsed = new LispParser("((lambda (x y) (+ 33 x y)) 10 20)").SExprs.run().get.head
+		testSuccessfulEvalSingle(parsed, Right((Val(63), empty)), empty)
 	}	
 
 	"The Lisp Interpretter" should "evaluate apply a lambda's result to a defined function" in {
-		val defined   = new LispParser("(define f (lambda (x) (+ x 10)))").SExprComplete.run()
-		val evald     = LispInterpretter.evaluate(defined.get)(empty)
+		val defined   = new LispParser("(define f (lambda (x) (+ x 10)))").SExprs.run().get.head
+		val evald     = LispInterpretter.evaluate(defined)(empty)
 		val newMap: M = evald match { case Right((_, m)) => m }
-		val res       = new LispParser("(f ((lambda (x) (+ x x)) 10))").SExprComplete.run()
-		testSuccessfulEval(res, Right((Val(30), newMap)), newMap)
+		val res       = new LispParser("(f ((lambda (x) (+ x x)) 10))").SExprs.run().get.head
+		testSuccessfulEvalSingle(res, Right((Val(30), newMap)), newMap)
 	}
 
-	def testSuccessfulEval(parsed: Try[SExpr], 
-						   expected: Either[(LispError, M), (MValue, M)], 
-						   map: M): Unit = parsed match {
-		case Success(e) => assert (LispInterpretter.evaluate(e)(map) == expected)
-		case Failure(_) => assert (false)
-	}
+	def testSuccessfulEvalSingle(parsed: SExpr, 
+						  	     expected: Either[(LispError, M), (MValue, M)], 
+						   		 map: M): Unit = 
+		assert (LispInterpretter.evaluate(parsed)(map) == expected)
 }

--- a/src/test/scala/net/parser/ParserTest.scala
+++ b/src/test/scala/net/parser/ParserTest.scala
@@ -7,83 +7,83 @@ import scala.util.{Success, Failure, Try}
 class ParserTest extends FlatSpec {
 
 	"The Lisp Parser" should "parse an Atom" in {
-		val result = new LispParser("1234").SExprComplete.run() 
+		val result = new LispParser("1234").SExprs.run() 
 		assert( result == Success(Number(1234)) )
 	}
 
 	"The Lisp Parser" should "parse an Ident" in {
-		val result = new LispParser("foobar").SExprComplete.run() 
+		val result = new LispParser("foobar").SExprs.run() 
 		assert( result == Success(Ident("foobar")) )
 	}	
 
 	"The Lisp Parser" should "parse a nested Atom" in {
-		val result = new LispParser("(5555)").SExprComplete.run() 
+		val result = new LispParser("(5555)").SExprs.run() 
 		assert( result == Success(Comb(List(Number(5555)))) )
 	}			
 
 	"The Lisp Parser" should "parse a nested Ident" in {
-		val result = new LispParser("(bippy)").SExprComplete.run() 
+		val result = new LispParser("(bippy)").SExprs.run() 
 		assert( result == Success(Comb(List(Ident("bippy")))) )
 	}			
 
 	"The Lisp Parser" should "fail on a doubley parenthesis Ident" in {
-		val result = new LispParser("((  BOOYAH ))").SExprComplete.run() 
+		val result = new LispParser("((  BOOYAH ))").SExprs.run() 
 		assert( result == Success(Comb(List(Comb(List(Ident("BOOYAH")))))) )
 	}				
 
 	"The Lisp Parser" should "simple S Expression" in {
-		val result = new LispParser("(bar (foo) 3 5 874)").SExprComplete.run() 
+		val result = new LispParser("(bar (foo) 3 5 874)").SExprs.run() 
 		assert(result == Success(Comb(List(Ident("bar"), Comb(List(Ident("foo"))), Number(3), Number(5), Number(874)))))
 	}				
 
 	"The Lisp Parser" should "somewhat complex S Expression" in {
-		val result = new LispParser("(((lambda x (lambda y (plus x y))) 3) 5)").SExprComplete.run() 
+		val result = new LispParser("(((lambda x (lambda y (plus x y))) 3) 5)").SExprs.run() 
 		assert(result == Success(Comb(List(Comb(List(Comb(List(Ident("lambda"), Ident("x"), Comb(List(Ident("lambda"), Ident("y"), Comb(List(Ident("plus"), Ident("x"), Ident("y"))))))), Number(3))), Number(5)))))
 	}				
 
 	"The Lisp Parser" should "parse an SExpression with a lot of spaces" in {
-		val result = new LispParser("( lots of ( spaces in ) this ( one ) )").SExprComplete.run() 
+		val result = new LispParser("( lots of ( spaces in ) this ( one ) )").SExprs.run() 
 		assert(result == Success(Comb(List(Ident("lots"), Ident("of"), Comb(List(Ident("spaces"), Ident("in"))), Ident("this"), Comb(List(Ident("one")))))))
 	}				
 
 	"The Lisp Parser" should "parse a simple SExpression #2" in {
-		val result = new LispParser("(+ x (+ y 1))").SExprComplete.run()
+		val result = new LispParser("(+ x (+ y 1))").SExprs.run()
 		assert(result == Success(Comb(List(Ident("+"), Ident("x"), Comb(List(Ident("+"), Ident("y"), Number(1)))))))
 	}	
 
 	"The Lisp Parser" should "parse a simple if expression" in {
-		val result = new LispParser("(if (> 10 20) (+ 1 1) (+ 3 3))").SExprComplete.run()
+		val result = new LispParser("(if (> 10 20) (+ 1 1) (+ 3 3))").SExprs.run()
 		assert(result == Success(Comb(List(Ident("if"), Comb(List(Ident(">"), Number(10), Number(20))), Comb(List(Ident("+"), Number(1), Number(1))), Comb(List(Ident("+"), Number(3), Number(3)))))))
 	}
 
 	"The Lisp Parser" should "fail if the SExpression has unmatched input" in {
-		val result = new LispParser("(bippy) ......").SExprComplete.run() 
+		val result = new LispParser("(bippy) ......").SExprs.run() 
 		assertBadParse(result)
 	}	
 
 	"The Lisp Parser" should "succeed for a valid SExpresison with extra trailing whitespace." in {
-		val result = new LispParser("(bippy) ").SExprComplete.run() 
+		val result = new LispParser("(bippy) ").SExprs.run() 
 		assert(result == Success(Comb(List(Ident(("bippy"))))))
 	}		
 
 	"The Lisp Parser" should "succeed for a valid 'set!' SExpression" in {
-		val result = new LispParser("(set! x 100)").SExprComplete.run() 
+		val result = new LispParser("(set! x 100)").SExprs.run() 
 		assert(result == Success(Comb(List(Ident("set!"), Ident("x"), Number(100)))))
 	}			
 
 	"The Lisp Parser" should "fail for an invalid 'set!' SExpression using a string literal \"set!\"" in {
-		val result = new LispParser("(\"set!\" x 100)").SExprComplete.run() 
+		val result = new LispParser("(\"set!\" x 100)").SExprs.run() 
 		assertBadParse(result)
 	}				
 
 	"The Lisp Parser" should "succeed for a non-simple set! SExpression" in {
-		val result = new LispParser("(set! x (+ (+ 0 100) 1 2))").SExprComplete.run() 
+		val result = new LispParser("(set! x (+ (+ 0 100) 1 2))").SExprs.run() 
 		assert(result == 
 			Success(Comb(List(Ident("set!"), Ident("x"), Comb(List(Ident("+"), Comb(List(Ident("+"), Number(0), Number(100))), Number(1), Number(2)))))))
 	}					
 
 	"The Lisp Parser" should "fails for a valid SExpresison, yet has extra whitespace + invalid characters" in {
-		val result = new LispParser("(bippy)      zzzzz ").SExprComplete.run() 
+		val result = new LispParser("(bippy)      zzzzz ").SExprs.run() 
 		assertBadParse(result)
 	}		
 

--- a/src/test/scala/net/parser/ParserTest.scala
+++ b/src/test/scala/net/parser/ParserTest.scala
@@ -8,52 +8,52 @@ class ParserTest extends FlatSpec {
 
 	"The Lisp Parser" should "parse an Atom" in {
 		val result = new LispParser("1234").SExprs.run() 
-		assert( result == Success(Number(1234)) )
+		assert( result == Success(Vector(Number(1234)) ))
 	}
 
 	"The Lisp Parser" should "parse an Ident" in {
 		val result = new LispParser("foobar").SExprs.run() 
-		assert( result == Success(Ident("foobar")) )
+		assert( result == Success(Vector(Ident("foobar")) ))
 	}	
 
 	"The Lisp Parser" should "parse a nested Atom" in {
 		val result = new LispParser("(5555)").SExprs.run() 
-		assert( result == Success(Comb(List(Number(5555)))) )
+		assert( result == Success(Vector(Comb(List(Number(5555)))) ))
 	}			
 
 	"The Lisp Parser" should "parse a nested Ident" in {
 		val result = new LispParser("(bippy)").SExprs.run() 
-		assert( result == Success(Comb(List(Ident("bippy")))) )
+		assert( result == Success(Vector(Comb(List(Ident("bippy")))) ))
 	}			
 
 	"The Lisp Parser" should "fail on a doubley parenthesis Ident" in {
 		val result = new LispParser("((  BOOYAH ))").SExprs.run() 
-		assert( result == Success(Comb(List(Comb(List(Ident("BOOYAH")))))) )
+		assert( result == Success(Vector(Comb(List(Comb(List(Ident("BOOYAH")))))) ))
 	}				
 
 	"The Lisp Parser" should "simple S Expression" in {
 		val result = new LispParser("(bar (foo) 3 5 874)").SExprs.run() 
-		assert(result == Success(Comb(List(Ident("bar"), Comb(List(Ident("foo"))), Number(3), Number(5), Number(874)))))
+		assert(result == Success(Vector(Comb(List(Ident("bar"), Comb(List(Ident("foo"))), Number(3), Number(5), Number(874))))))
 	}				
 
 	"The Lisp Parser" should "somewhat complex S Expression" in {
 		val result = new LispParser("(((lambda x (lambda y (plus x y))) 3) 5)").SExprs.run() 
-		assert(result == Success(Comb(List(Comb(List(Comb(List(Ident("lambda"), Ident("x"), Comb(List(Ident("lambda"), Ident("y"), Comb(List(Ident("plus"), Ident("x"), Ident("y"))))))), Number(3))), Number(5)))))
+		assert(result == Success(Vector(Comb(List(Comb(List(Comb(List(Ident("lambda"), Ident("x"), Comb(List(Ident("lambda"), Ident("y"), Comb(List(Ident("plus"), Ident("x"), Ident("y"))))))), Number(3))), Number(5))))))
 	}				
 
 	"The Lisp Parser" should "parse an SExpression with a lot of spaces" in {
 		val result = new LispParser("( lots of ( spaces in ) this ( one ) )").SExprs.run() 
-		assert(result == Success(Comb(List(Ident("lots"), Ident("of"), Comb(List(Ident("spaces"), Ident("in"))), Ident("this"), Comb(List(Ident("one")))))))
+		assert(result == Success(Vector(Comb(List(Ident("lots"), Ident("of"), Comb(List(Ident("spaces"), Ident("in"))), Ident("this"), Comb(List(Ident("one"))))))))
 	}				
 
 	"The Lisp Parser" should "parse a simple SExpression #2" in {
 		val result = new LispParser("(+ x (+ y 1))").SExprs.run()
-		assert(result == Success(Comb(List(Ident("+"), Ident("x"), Comb(List(Ident("+"), Ident("y"), Number(1)))))))
+		assert(result == Success(Vector(Comb(List(Ident("+"), Ident("x"), Comb(List(Ident("+"), Ident("y"), Number(1))))))))
 	}	
 
 	"The Lisp Parser" should "parse a simple if expression" in {
 		val result = new LispParser("(if (> 10 20) (+ 1 1) (+ 3 3))").SExprs.run()
-		assert(result == Success(Comb(List(Ident("if"), Comb(List(Ident(">"), Number(10), Number(20))), Comb(List(Ident("+"), Number(1), Number(1))), Comb(List(Ident("+"), Number(3), Number(3)))))))
+		assert(result == Success(Vector(Comb(List(Ident("if"), Comb(List(Ident(">"), Number(10), Number(20))), Comb(List(Ident("+"), Number(1), Number(1))), Comb(List(Ident("+"), Number(3), Number(3))))))))
 	}
 
 	"The Lisp Parser" should "fail if the SExpression has unmatched input" in {
@@ -63,12 +63,12 @@ class ParserTest extends FlatSpec {
 
 	"The Lisp Parser" should "succeed for a valid SExpresison with extra trailing whitespace." in {
 		val result = new LispParser("(bippy) ").SExprs.run() 
-		assert(result == Success(Comb(List(Ident(("bippy"))))))
+		assert(result == Success(Vector(Comb(List(Ident(("bippy")))))))
 	}		
 
 	"The Lisp Parser" should "succeed for a valid 'set!' SExpression" in {
 		val result = new LispParser("(set! x 100)").SExprs.run() 
-		assert(result == Success(Comb(List(Ident("set!"), Ident("x"), Number(100)))))
+		assert(result == Success(Vector(Comb(List(Ident("set!"), Ident("x"), Number(100))))))
 	}			
 
 	"The Lisp Parser" should "fail for an invalid 'set!' SExpression using a string literal \"set!\"" in {
@@ -79,16 +79,17 @@ class ParserTest extends FlatSpec {
 	"The Lisp Parser" should "succeed for a non-simple set! SExpression" in {
 		val result = new LispParser("(set! x (+ (+ 0 100) 1 2))").SExprs.run() 
 		assert(result == 
-			Success(Comb(List(Ident("set!"), Ident("x"), Comb(List(Ident("+"), Comb(List(Ident("+"), Number(0), Number(100))), Number(1), Number(2)))))))
+			Success(Vector(Comb(List(Ident("set!"), Ident("x"), Comb(List(Ident("+"), Comb(List(Ident("+"), Number(0), Number(100))), Number(1), Number(2)))))))
+			)
 	}					
 
-	"The Lisp Parser" should "fails for a valid SExpresison, yet has extra whitespace + invalid characters" in {
+	"The Lisp Parser" should "succeed for SExpr's separated by white-space." in {
 		val result = new LispParser("(bippy)      zzzzz ").SExprs.run() 
-		assertBadParse(result)
+		assert(result == Success(Vector(Comb(List(Ident("bippy"))), Ident("zzzzz"))))
 	}		
 
 	def assertBadParse[A](result: Try[A]) = result match {
-		case Failure(_) => true
-		case Success(_)	=> false
+		case Failure(_)         => true
+		case Success(Vector(_))	=> false
 	}		
 }

--- a/src/test/scala/net/repl/LispReplTest.scala
+++ b/src/test/scala/net/repl/LispReplTest.scala
@@ -1,0 +1,60 @@
+package net.repl
+
+import net.repl.LispRepl._
+import org.scalatest._
+import net.parser.AST._
+import net.common.Error._
+
+class LispReplTest extends FlatSpec {
+	
+	"Evaluating 2 SExpressions" should "succeed when defining a lambda and appying it" in {
+		val str = "(define double (lambda (x) (+ x x))) (double 10)"
+		val result: Either[LispError, List[Either[(LispError, M), (MValue, M)]]] = evalString(str)
+		result match {
+			case Right(x :: y :: Nil) => assert(getRightValue(x) == Some(Val(Lambda)) && getRightValue(y) == Some(Val(20)))
+			case _                    => assert(false)
+		}
+	}
+
+	"Evaluating 3 SExpressions" should "succeed where each SExpr is simply a Number" in {
+		val str = "10 20 30"
+		val result: Either[LispError, List[Either[(LispError, M), (MValue, M)]]] = evalString(str)
+		result match {
+			case Right(x :: y :: z :: Nil) => assert(getRightValue(x) == Some(Val(10)) && getRightValue(y) == Some(Val(20)) && getRightValue(z) == Some(Val(30)))
+			case _                         => assert(false)
+		}
+	}	
+
+	"Evaluating 3 SExpressions" should "succeed where the first 2 are define's, but the third adds them" in {
+		val str = "(define x 10) (define y 20) (+ x y)"
+		val result: Either[LispError, List[Either[(LispError, M), (MValue, M)]]] = evalString(str)
+		result match {
+			case Right(x :: y :: z :: Nil) => assert(getRightValue(x) == Some(Val(Op)) && getRightValue(y) == Some(Val(Op)) && getRightValue(z) == Some(Val(30)))
+			case _                         => assert(false)
+		}
+	}		
+
+	"Evaluating an SExpression" should "should return a Parse Error where the first fails to parse" in {
+		val str = "(define x 10"
+		val result: Either[LispError, List[Either[(LispError, M), (MValue, M)]]] = evalString(str)
+		result match {
+			case Left(ParseError(_)) => assert(true)
+			case _                   => assert(false)
+		}
+	}		
+
+	"Evaluating 2 SExpression's" should "parse successfully, evaluate the first, but fail to evaluate the second" in {
+		val str = "1000 (+ x 1)"
+		val result: Either[LispError, List[Either[(LispError, M), (MValue, M)]]] = evalString(str)
+		result match {
+			case Right(x :: Left((NoVarExists("x"), _)) :: Nil) => assert(getRightValue(x) == Some(Val(1000))) 
+			case _                                         => assert(false)
+		}
+	}		
+
+	private def getRightValue[A,B,C,D](x: Either[(A, C), (B, D)]): Option[B] = x match {
+		case Right((x,_)) => Some(x)
+		case Left(_)      => None
+	} 
+
+}


### PR DESCRIPTION
Enables parsing and evaluating multiple SExpression.

Check out `net.repl.LispReplTest` for related tests.
